### PR TITLE
Version 3.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -511,13 +511,14 @@ checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
 name = "gru"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "arguments",
  "console",
  "execute",
  "isahc",
  "press-btn-continue",
+ "regex",
  "serde_json",
  "tokio",
  "trauma",
@@ -1229,9 +1230,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.3"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1241,9 +1242,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.6"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1252,9 +1253,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.2"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "reqwest"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gru"
-version = "3.0.2"
+version = "3.1.0"
 edition = "2021"
 authors = ["Zalexanninev15 <blue.shark@disroot.org>"]
 license = "MIT License"
@@ -14,7 +14,7 @@ winconsole = "0.11.1"
 press-btn-continue = "0.2.0"
 arguments = "0.8.0"
 isahc = "1.7.2"
-serde_json = { version = "1.0.140", default-features = false, features = [
+serde_json = { version = "1.0.138", default-features = false, features = [
   "alloc",
 ] }
 trauma = "2.2.4"
@@ -27,6 +27,7 @@ winapi = { version = "0.3.9", features = [
   "winbase",
   "securitybaseapi",
 ] }
+regex = "1.11.1"
 
 [profile.release]
 strip = true

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Updater for applications from GitHub. It has a huge number of convenient setting
 - `--tool <type>` — Choose between download tools like `curl`, `wget`, `gru`, `gru-classic`, or `tcpud` (curl-only).
 - `--link <url>` — Use a direct download link when assets are unavailable in the release.
 - `--ua <user-agent>` — Customize the user-agent string for optimized download speeds.
+- `--regex` / `--no-regex` — Use `--with` to search using a regular expression instead of a regular match.
 - `--gh <personal access token>` — Use a GitHub personal access token for improved access if there are restrictions.
 - `--wgetrc` / `--no-wgetrc` — Use the wget configuration file (.wgetrc).
 - `--pre` / `--no-pre` — Use pre-releases if stable versions are unavailable.

--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ Updater for applications from GitHub. It has a huge number of convenient setting
 - **Asset Search Across Multiple Releases**: Search for assets across multiple recent releases (not just the latest), ensuring you always get the right version of the file.
 
 ## Available arguments
+
+> To better understand this, the developer recommends reading the information about arguments in the utility itself, as it contains more details.
+
 - `--app <application.exe>` — Set the EXE of the launcher/main application.
 - `--main <path>` — Set the path to the main application located one level above the EXE.
 - `--extract` / `--no-extract` — Decide whether to extract archive files or simply move the downloaded EXE.
@@ -42,7 +45,7 @@ Updater for applications from GitHub. It has a huge number of convenient setting
 - `--details` / `--no-details` — Show detailed download information using curl/wget.
 - `--nupkg` / `--no-nupkg` —  Enabling the correct operation mode with nuget packages (.nupkg), which include the release of the downloaded application itself.
 - `--tool <type>` — Choose between download tools like `curl`, `wget`, `gru`, `gru-classic`, or `tcpud` (curl-only).
-- `--link <url>` — Use a direct download link when assets are unavailable in the release.
+- `--link <url>` — Use a direct download link when assets are unavailable in the release. Sometimes releases may not contain assets to download, but just be a place for a list of changes (What's new?). Supports version substitution in the link to the version from GitHub, if such a rule is implied by the developer of the downloaded application. To do this, enter the text `<version>` in the appropriate place, and it will be replaced with the version from GitHub.
 - `--ua <user-agent>` — Customize the user-agent string for optimized download speeds.
 - `--regex` / `--no-regex` — Use `--with` to search using a regular expression instead of a regular match.
 - `--gh <personal access token>` — Use a GitHub personal access token for improved access if there are restrictions.
@@ -105,6 +108,12 @@ gru.exe --repo microsoft/vscode --app Code.exe --with "null" --link "https://cod
 
 ```batch
 gru.exe --repo Kong/insomnia --app insomnia.exe --with "-full.nupkg" --nupkg
+```
+
+### [OBS Studio](https://github.com/obsproject/obs-studio)
+
+```batch
+gru.exe --repo obsproject/obs-studio --app obs64.exe --with "^OBS-Studio-(\d+\.\d+\.\d+)-Windows(-(?:x64|amd64|Portable|Portable-x64|x64-Portable))?\.zip$" --regex --main bin\64bit\obs64.exe
 ```
 
 ## Build

--- a/src/main.rs
+++ b/src/main.rs
@@ -96,7 +96,6 @@ fn main() {
         let is_script_after = arguments.get::<bool>("script").unwrap_or(false);
         let silent_mode = arguments.get::<bool>("silent").unwrap_or(false);
         let details = arguments.get::<bool>("details").unwrap_or(false);
-		let with_as_regex = arguments.get::<bool>("regex").unwrap_or(false);
         let tool = arguments.get::<String>("tool").unwrap_or("gru".to_string());
         let d_link = arguments.get::<String>("link").unwrap_or("null".to_string());
         let mut no_ghost = arguments.get::<bool>("ghost").unwrap_or(false);
@@ -107,6 +106,7 @@ fn main() {
             .unwrap_or(
                 "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/132.0.0.0 Safari/537.36".to_string()
             );
+		let with_as_regex = arguments.get::<bool>("regex").unwrap_or(false);
         let wgetrc = arguments.get::<bool>("wgetrc").unwrap_or(false);
         let show_pre = arguments.get::<bool>("pre").unwrap_or(false);
         let debug_mode = arguments.get::<bool>("debug").unwrap_or(false);
@@ -141,6 +141,7 @@ fn main() {
             println!("[Debug] tool = \"{}\"", tool);
             println!("[Debug] d_link = {}", d_link);
             println!("[Debug] ua = \"{}\"", ua);
+            println!("[Debug] with_as_regex = \"{}\"", with_as_regex);
             println!("[Debug] wgetrc = {}", wgetrc);
             println!("[Debug] show_pre = {}", show_pre);
             println!("[Debug] no_ghost = {}", no_ghost);
@@ -242,7 +243,7 @@ fn main() {
             // Downloading the file
             println!("Downloading...");
             if v_list_asset.contains(&part) == false && d_link != "null" {
-                repo = d_link;
+                repo = d_link.replace("<version>", &v_list_version);
             }
             let _ = downloader::download(
                 &repo,
@@ -358,8 +359,9 @@ OPTIONS:
                                   them (to executable files) can be specified in the files \"curl.txt\" or \"wget.txt\".
                                   If there is an error finding an executable file, the built-in file downloader will be invoked.
                                   Default: 'gru'.
-    --link <url>                  Sometimes releases may not contain assets to download, but just be a place for a list of changes (what's new?). 
-                                  Set the download link (direct) to the release in other place. Default: null.
+    --link <url>                  Sometimes releases may not contain assets to download, but just be a place for a list of changes (What's new?). Set the download link (direct) to the release in other place.
+                                  Supports version substitution in the link to the version from GitHub, if such a rule is implied by the developer of the downloaded application. To do this, enter the text `<version>`
+								  in the appropriate place, and it will be replaced with the version from GitHub. Default: null.
     --ua <user-agent>             Specify a user-agent for better download speed. The argument applies to the 'curl' and 'wget' tools and GitHub API requests.
                                   Default: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/132.0.0.0 Safari/537.36.
     --regex / --no-regex	  Use '--with' to search using a regular expression instead of a regular match. Default: --no-regex.

--- a/src/main.rs
+++ b/src/main.rs
@@ -96,6 +96,7 @@ fn main() {
         let is_script_after = arguments.get::<bool>("script").unwrap_or(false);
         let silent_mode = arguments.get::<bool>("silent").unwrap_or(false);
         let details = arguments.get::<bool>("details").unwrap_or(false);
+		let with_as_regex = arguments.get::<bool>("regex").unwrap_or(false);
         let tool = arguments.get::<String>("tool").unwrap_or("gru".to_string());
         let d_link = arguments.get::<String>("link").unwrap_or("null".to_string());
         let mut no_ghost = arguments.get::<bool>("ghost").unwrap_or(false);
@@ -160,9 +161,9 @@ fn main() {
 
         // Getting the new version release
         let (v_list_version, mut v_list_asset) = if api_token == "null" {
-            json::parse_data(&repo, &part, &show_pre, &no_ghost, &ua, None)
+            json::parse_data(&repo, &part, &show_pre, &no_ghost, &ua, None, &with_as_regex)
         } else {
-            json::parse_data(&repo, &part, &show_pre, &no_ghost, &ua, Some(&api_token))
+            json::parse_data(&repo, &part, &show_pre, &no_ghost, &ua, Some(&api_token), &with_as_regex)
         };
 
         if debug_mode {
@@ -361,6 +362,7 @@ OPTIONS:
                                   Set the download link (direct) to the release in other place. Default: null.
     --ua <user-agent>             Specify a user-agent for better download speed. The argument applies to the 'curl' and 'wget' tools and GitHub API requests.
                                   Default: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/132.0.0.0 Safari/537.36.
+    --regex / --no-regex	  Use '--with' to search using a regular expression instead of a regular match. Default: --no-regex.
     --gh <personal access token>  Use a Personal access token to request access to GitHub if there are problems with access on the GitHub 
                                   side due to restrictions imposed by them.
                                   Get personal access token: https://github.com/settings/personal-access-tokens


### PR DESCRIPTION
Changes:
- Added asset search by regular expressions (`--regex`)
Example: 
```batch
gru.exe --repo obsproject/obs-studio --app obs64.exe --with "^OBS-Studio-(\d+\.\d+\.\d+)-Windows(-(?:x64|amd64|Portable|Portable-x64|x64-Portable))?\.zip$" --regex --main bin\64bit\obs64.exe
```
- Added a feature to replace the version number in a direct link specified using `--link`, based on the version obtained from GitHub using the “magic” text `<version>` inserted in the appropriate place in the link.